### PR TITLE
[FEAT] Make Finnish invoice replace default Odoo invoice (#5)

### DIFF
--- a/model/account_invoice.py
+++ b/model/account_invoice.py
@@ -99,16 +99,3 @@ class AccountInvoice(models.Model):
         help=_('https://www.fkl.fi/teemasivut/sepa/tekninen_dokumentaatio/Dok'
                'umentit/Pankkiviivakoodi-opas.pdf')
     )
-
-    @api.multi
-    def invoice_print(self):
-        """ Print the invoice and mark it as sent, so that we can see more
-            easily the next step of the workflow
-        """
-        assert len(self) == 1, \
-            'This option should only be used for a single id at a time.'
-        # noinspection PyAttributeOutsideInit
-        self.sent = True
-        return self.env['report']\
-            .get_action(self,
-                        'l10n_fi_invoice.report_invoice_finnish_translate')

--- a/report/report_invoice.xml
+++ b/report/report_invoice.xml
@@ -1,516 +1,590 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
-        <template id="report_invoice_finnish_document">
-            <t t-name="account.report_invoice_document">
-                <t t-call="l10n_fi_invoice.report_layout_finnish">
-                    <div class="header" style="height: 2.62cm; position: relative;">
-                        <style type="text/css">
-                            .padding-correction {
-                            padding-right: 15px;
-                            padding-left: 15px;
-                            }
-                        </style>
-                        <div class="padding-correction" style="position: absolute; width: 100%; bottom: 0;">
-                            <div class="row">
-                                <div class="col-xs-2 col-xs-offset-1"
-                                     style="float: none; display: inline-block; vertical-align: middle;">
-                                    <img t-if="doc.company_id.logo"
-                                         t-att-src="'data:image/png;base64,%s' % doc.company_id.logo"
-                                         style="max-height: 2.1cm; max-width: 4cm;"/>
-                                </div>
-                                <div class="col-xs-4"
-                                     style="font-size: .85em; float: none; display: inline-block; vertical-align: middle;">
-                                    <div t-field="doc.company_id.partner_id"
-                                         t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
-                                </div>
-                                <div class="col-xs-5 text-left"
-                                     style="font-weight: bold; font-size: large; float: none; display: inline-block; vertical-align: bottom; width: auto; padding-left: 5px;">
-                                    <span>Invoice</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="page">
-                        <!-- Custom CSS for reports is not trivial, see here:
-                            https://github.com/odoo/odoo/issues/4359
-                            Easier to just insert inline, since we aren't changing multiple reports -->
-                        <style type="text/css">
-                            .padding-correction {
-                            padding-right: 15px;
-                            padding-left: 15px;
-                            }
-
-                            hr {
-                            border-top: 2px solid #eee;
-                            margin-left: -15px;
-                            margin-right: -15px;
-                            margin-top: 10px;
-                            margin-bottom: 10px;
-                            }
-
-                            .bank-transfer-wrap .row .row > div {
-                            padding-top: 5px;
-                            padding-bottom: 5px;
-                            }
-
-                            .bank-transfer-label {
-                            font-size: 9px;
-                            text-align: right;
-                            line-height: 10px;
-                            padding: 3px;
-                            }
-
-                            .bank-transfer-value {
-                            line-height: 1.7em;
-                            }
-
-                            .text-left {
-                            text-align: left;
-                            }
-
-                            .border-right {
-                            border-right: 2px solid black;
-                            }
-
-                            .border-left {
-                            border-left: 2px solid black;
-                            }
-
-                            .border-bottom {
-                            border-bottom: 2px solid black;
-                            }
-
-                            .medium-row > div {
-                            height: 4.9em;
-                            }
-
-                            .small-row > div {
-                            height: 2.5em;
-                            }
-
-                            .invoice-info tr td:last-child {
-                            padding-left: 3em;
-                            }
-
-                            address span[itemprop=name] {
-                            font-weight: bold;
-                            }
-
-                            .table-condensed > thead > tr > th {
-                            border-bottom: none;
-                            }
-
-                            .table > tbody > tr > td {
-                            border-top: none;
-                            }
-
-                            table.products-table {
-                            border-bottom: 1px solid #eee;
-                            }
-
-                            table.products-table-totals td {
-                            text-align: right;
-                            line-height: .9em !important;
-                            }
-
-                            .totals-col {
-                            width: 8em;
-                            font-weight: bold;
-                            }
-
-                            .line_number {
-                            color: gray;
-                            position: absolute;
-                            }
-
-                            .payment-terms {
-                            font-size: .7em;
-                            margin-top: .5em;
-                            line-height: 1em;
-                            }
-
-                            .payment-terms p {
-                            margin-bottom: 0;
-                            }
-                        </style>
-                        <div class="padding-correction" style="min-height: 11.3cm">
-                            <div class="row">
-                                <div class="col-xs-6 col-xs-offset-1"
-                                     style="margin-top: 10em; margin-bottom: 4em; font-size:1.1em;">
-                                    <address t-field="doc.partner_id"
+        <template id="report_invoice_finnish_document" inherit_id="account.report_invoice_document">
+            <xpath expr="//t" position="replace">
+                <t t-name="account.report_invoice_document">
+                    <t t-call="l10n_fi_invoice.report_layout_finnish">
+                        <div class="header"
+                             style="height: 2.62cm; position: relative;">
+                            <style type="text/css">
+                                .padding-correction {
+                                padding-right: 15px;
+                                padding-left: 15px;
+                                }
+                            </style>
+                            <div class="padding-correction"
+                                 style="position: absolute; width: 100%; bottom: 0;">
+                                <div class="row">
+                                    <div class="col-xs-2 col-xs-offset-1"
+                                         style="float: none; display: inline-block; vertical-align: middle;">
+                                        <img t-if="o.company_id.logo"
+                                             t-att-src="'data:image/png;base64,%s' % o.company_id.logo"
+                                             style="max-height: 2.1cm; max-width: 4cm;"/>
+                                    </div>
+                                    <div class="col-xs-4"
+                                         style="font-size: .85em; float: none; display: inline-block; vertical-align: middle;">
+                                        <div t-field="o.company_id.partner_id"
                                              t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
-                                    <span t-if="doc.partner_id.vat">VAT:
-                                        <span t-field="doc.partner_id.vat"/>
-                                    </span>
-                                </div>
-                                <div class="col-xs-5">
-                                    <table class="invoice-info"
-                                           style="line-height: 1.5em; position:relative; top: 7.5em;">
-                                        <tr>
-                                            <td>
-                                                <span>Invoice number</span>
-                                            </td>
-                                            <td>
-                                                <t t-esc="doc.number"/>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <span>Invoice reference</span>
-                                            </td>
-                                            <td>
-                                                <t t-esc="doc.ref_number"/>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>Invoice Date</td>
-                                            <td>
-                                                <span t-field="doc.date_invoice"/>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <span>Date due</span>
-                                            </td>
-                                            <td>
-                                                <span t-field="doc.date_due"/>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>Date fulfilled</td>
-                                            <td>
-                                                <span t-field="doc.date_delivered"/>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>Payment term</td>
-                                            <td>
-                                                <span t-field="doc.payment_term_id"/>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>Our reference</td>
-                                            <td>
-                                                <span t-field="doc.origin"/>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>Your reference</td>
-                                            <td>
-                                                <span t-field="doc.name"/>
-                                            </td>
-                                        </tr>
-                                    </table>
+                                    </div>
+                                    <div class="col-xs-5 text-left"
+                                         style="font-weight: bold; font-size: large; float: none; display: inline-block; vertical-align: bottom; width: auto; padding-left: 5px;">
+                                        <span>Invoice</span>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                        <hr/>
-                        <div class="padding-correction" style="min-height: 13.70cm;">
-                            <div style="margin-bottom: 1em;">
-                                <span t-field="doc.comment"/>
-                            </div>
-                            <table class="table table-condensed products-table">
-                                <thead>
-                                    <tr>
-                                        <th>
-                                            <span class="col-xs-offset-2">Description</span>
-                                        </th>
-                                        <th>Quantity</th>
-                                        <th class="text-right">Unit Price</th>
-                                        <th class="text-right" groups="sale.group_discount_per_so_line">Discount (%)
-                                        </th>
-                                        <th class="text-right">Taxes</th>
-                                        <th class="text-right totals-col">Amount</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="invoice_tbody">
-                                    <tr t-foreach="doc.invoice_line_ids" t-as="l">
-                                        <td>
-                                            <span class="line_number" t-esc="str(l_index+1) + '.'"/>
-                                            <span class="col-xs-offset-2" t-field="l.name"/>
-                                        </td>
-                                        <td>
-                                            <span t-field="l.quantity"/>
-                                            <span t-field="l.uom_id" groups="product.group_uom"/>
-                                        </td>
-                                        <td class="text-right">
-                                            <span t-field="l.price_unit"/>
-                                        </td>
-                                        <td class="text-right" groups="sale.group_discount_per_so_line">
-                                            <span t-field="l.discount"/>
-                                        </td>
-                                        <td class="text-right">
-                                            <span t-esc="', '.join(map(lambda x: x.name, l.invoice_line_tax_ids))"/>
-                                        </td>
-                                        <td class="text-right">
-                                            <span t-field="l.price_subtotal"
-                                                  t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
+                        <div class="page">
+                            <!-- Custom CSS for reports is not trivial, see here:
+                                https://github.com/odoo/odoo/issues/4359
+                                Easier to just insert inline, since we aren't changing multiple reports -->
+                            <style type="text/css">
+                                .padding-correction {
+                                padding-right: 15px;
+                                padding-left: 15px;
+                                }
 
-                            <div class="row">
-                                <div class="col-xs-4 pull-right">
-                                    <table class="table table-condensed products-table-totals">
-                                        <tr>
-                                            <td>Total Without Taxes</td>
-                                            <td class="text-right totals-col">
-                                                <span t-field="doc.amount_untaxed"
-                                                      t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>Taxes</td>
-                                            <td class="text-right totals-col">
-                                                <span t-field="doc.amount_tax"
-                                                      t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>Total</td>
-                                            <td class="text-right totals-col">
-                                                <span t-field="doc.amount_total"
-                                                      t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
-                                            </td>
-                                        </tr>
-                                    </table>
-                                </div>
-                            </div>
+                                hr {
+                                border-top: 2px solid #eee;
+                                margin-left: -15px;
+                                margin-right: -15px;
+                                margin-top: 10px;
+                                margin-bottom: 10px;
+                                }
 
-                            <div class="row" t-if="doc.tax_line_ids">
-                                <div class="col-xs-6 col-xs-offset-6">
-                                    <table class="table table-condensed">
-                                        <thead>
+                                .bank-transfer-wrap .row .row > div {
+                                padding-top: 5px;
+                                padding-bottom: 5px;
+                                }
+
+                                .bank-transfer-label {
+                                font-size: 9px;
+                                text-align: right;
+                                line-height: 10px;
+                                padding: 3px;
+                                }
+
+                                .bank-transfer-value {
+                                line-height: 1.7em;
+                                }
+
+                                .text-left {
+                                text-align: left;
+                                }
+
+                                .border-right {
+                                border-right: 2px solid black;
+                                }
+
+                                .border-left {
+                                border-left: 2px solid black;
+                                }
+
+                                .border-bottom {
+                                border-bottom: 2px solid black;
+                                }
+
+                                .medium-row > div {
+                                height: 4.9em;
+                                }
+
+                                .small-row > div {
+                                height: 2.5em;
+                                }
+
+                                .invoice-info tr td:last-child {
+                                padding-left: 3em;
+                                }
+
+                                address span[itemprop=name] {
+                                font-weight: bold;
+                                }
+
+                                .table-condensed > thead > tr > th {
+                                border-bottom: none;
+                                }
+
+                                .table > tbody > tr > td {
+                                border-top: none;
+                                }
+
+                                table.products-table {
+                                border-bottom: 1px solid #eee;
+                                }
+
+                                table.products-table-totals td {
+                                text-align: right;
+                                line-height: .9em !important;
+                                }
+
+                                .totals-col {
+                                width: 8em;
+                                font-weight: bold;
+                                }
+
+                                .line_number {
+                                color: gray;
+                                position: absolute;
+                                }
+
+                                .payment-terms {
+                                font-size: .7em;
+                                margin-top: .5em;
+                                line-height: 1em;
+                                }
+
+                                .payment-terms p {
+                                margin-bottom: 0;
+                                }
+                            </style>
+                            <div class="padding-correction"
+                                 style="min-height: 11.3cm">
+                                <div class="row">
+                                    <div class="col-xs-6 col-xs-offset-1"
+                                         style="margin-top: 10em; margin-bottom: 4em; font-size:1.1em;">
+                                        <address t-field="o.partner_id"
+                                                 t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
+                                        <span t-if="o.partner_id.vat">VAT:
+                                            <span t-field="o.partner_id.vat"/>
+                                        </span>
+                                    </div>
+                                    <div class="col-xs-5">
+                                        <table class="invoice-info"
+                                               style="line-height: 1.5em; position:relative; top: 7.5em;">
                                             <tr>
-                                                <th>Tax</th>
-                                                <th class="text-right">Base</th>
-                                                <th class="text-right">Amount</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <tr t-foreach="doc.tax_line_ids" t-as="t">
                                                 <td>
-                                                    <span t-field="t.name"/>
+                                                    <span>Invoice number</span>
                                                 </td>
-                                                <td class="text-right">
-                                                    <span t-field="t.tax_id.amount"
-                                                          t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
-                                                </td>
-                                                <td class="text-right">
-                                                    <span t-field="t.amount"
-                                                          t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
+                                                <td>
+                                                    <t t-esc="o.number"/>
                                                 </td>
                                             </tr>
-                                        </tbody>
-                                    </table>
+                                            <tr>
+                                                <td>
+                                                    <span>Invoice reference
+                                                    </span>
+                                                </td>
+                                                <td>
+                                                    <t t-esc="o.ref_number"/>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td>Invoice Date</td>
+                                                <td>
+                                                    <span
+                                                        t-field="o.date_invoice"/>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td>
+                                                    <span>Date due</span>
+                                                </td>
+                                                <td>
+                                                    <span
+                                                        t-field="o.date_due"/>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td>Date fulfilled</td>
+                                                <td>
+                                                    <span
+                                                        t-field="o.date_delivered"/>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td>Payment term</td>
+                                                <td>
+                                                    <span
+                                                        t-field="o.payment_term_id"/>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td>Our reference</td>
+                                                <td>
+                                                    <span t-field="o.origin"/>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td>Your reference</td>
+                                                <td>
+                                                    <span t-field="o.name"/>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                        <hr/>
-                        <div class="bank-transfer-wrap last-page" style="page-break-inside: avoid;">
-                            <div class="row padding-correction" style="margin-bottom: 1em; font-size: .8em;">
-                                <div class="col-xs-4">
-                                    <div t-field="doc.company_id.partner_id"
-                                         t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
+                            <hr/>
+                            <div class="padding-correction"
+                                 style="min-height: 13.70cm;">
+                                <div style="margin-bottom: 1em;">
+                                    <span t-field="o.comment"/>
                                 </div>
-                                <div class="col-xs-4">
-                                    <div>
-                                        <span t-field="doc.company_id.phone"/>
-                                    </div>
-                                    <div>
-                                        <span t-field="doc.company_id.email"/>
-                                    </div>
-                                    <div>
-                                        <span t-field="doc.company_id.website"/>
+                                <table
+                                    class="table table-condensed products-table">
+                                    <thead>
+                                        <tr>
+                                            <th>
+                                                <span class="col-xs-offset-2">
+                                                    Description
+                                                </span>
+                                            </th>
+                                            <th>Quantity</th>
+                                            <th class="text-right">Unit Price
+                                            </th>
+                                            <th class="text-right"
+                                                groups="sale.group_discount_per_so_line">
+                                                Discount (%)
+                                            </th>
+                                            <th class="text-right">Taxes</th>
+                                            <th class="text-right totals-col">
+                                                Amount
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="invoice_tbody">
+                                        <tr t-foreach="o.invoice_line_ids"
+                                            t-as="l">
+                                            <td>
+                                                <span class="line_number"
+                                                      t-esc="str(l_index+1) + '.'"/>
+                                                <span class="col-xs-offset-2"
+                                                      t-field="l.name"/>
+                                            </td>
+                                            <td>
+                                                <span t-field="l.quantity"/>
+                                                <span t-field="l.uom_id"
+                                                      groups="product.group_uom"/>
+                                            </td>
+                                            <td class="text-right">
+                                                <span t-field="l.price_unit"/>
+                                            </td>
+                                            <td class="text-right"
+                                                groups="sale.group_discount_per_so_line">
+                                                <span t-field="l.discount"/>
+                                            </td>
+                                            <td class="text-right">
+                                                <span
+                                                    t-esc="', '.join(map(lambda x: x.name, l.invoice_line_tax_ids))"/>
+                                            </td>
+                                            <td class="text-right">
+                                                <span t-field="l.price_subtotal"
+                                                      t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+
+                                <div class="row">
+                                    <div class="col-xs-4 pull-right">
+                                        <table
+                                            class="table table-condensed products-table-totals">
+                                            <tr>
+                                                <td>Total Without Taxes</td>
+                                                <td class="text-right totals-col">
+                                                    <span
+                                                        t-field="o.amount_untaxed"
+                                                        t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td>Taxes</td>
+                                                <td class="text-right totals-col">
+                                                    <span
+                                                        t-field="o.amount_tax"
+                                                        t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td>Total</td>
+                                                <td class="text-right totals-col">
+                                                    <span
+                                                        t-field="o.amount_total"
+                                                        t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                </td>
+                                            </tr>
+                                        </table>
                                     </div>
                                 </div>
-                                <div class="col-xs-4">
-                                    <div t-if="doc.company_id.city">Kotipaikka:
-                                        <span t-field="doc.company_id.city"/>
-                                    </div>
-                                    <div>Y-tunnus:
-                                        <span t-field="doc.company_id.company_registry"/>
+
+                                <div class="row" t-if="o.tax_line_ids">
+                                    <div class="col-xs-6 col-xs-offset-6">
+                                        <table class="table table-condensed">
+                                            <thead>
+                                                <tr>
+                                                    <th>Tax</th>
+                                                    <th class="text-right">
+                                                        Base
+                                                    </th>
+                                                    <th class="text-right">
+                                                        Amount
+                                                    </th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr t-foreach="o.tax_line_ids"
+                                                    t-as="t">
+                                                    <td>
+                                                        <span t-field="t.name"/>
+                                                    </td>
+                                                    <td class="text-right">
+                                                        <span
+                                                            t-field="t.tax_id.amount"
+                                                            t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                    </td>
+                                                    <td class="text-right">
+                                                        <span t-field="t.amount"
+                                                              t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
                                     </div>
                                 </div>
                             </div>
-                            <div class="row row-eq-height border-bottom" style="border-top: 1px dashed gray">
-                                <div class="col-xs-7 border-right">
-                                    <div class="row row-eq-height border-bottom medium-row">
-                                        <div class="col-xs-2 bank-transfer-label">
-                                            <div>
-                                                Saajan
-                                                tilinumero
-                                            </div>
-                                            <div>
-                                                Mottagarens
-                                                kontonummer
-                                            </div>
+                            <hr/>
+                            <div class="bank-transfer-wrap last-page"
+                                 style="page-break-inside: avoid;">
+                                <div class="row padding-correction"
+                                     style="margin-bottom: 1em; font-size: .8em;">
+                                    <div class="col-xs-4">
+                                        <div t-field="o.company_id.partner_id"
+                                             t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
+                                    </div>
+                                    <div class="col-xs-4">
+                                        <div>
+                                            <span
+                                                t-field="o.company_id.phone"/>
                                         </div>
-                                        <div class="col-xs-10 border-left">
-                                            <t t-if="doc.partner_bank_id.acc_number">
-                                                IBAN
-                                                <t t-esc="doc.partner_bank_id.acc_number"/>
-                                            </t>
-                                            <t t-if="not doc.partner_bank_id.acc_number">
-                                                <t t-foreach="doc.company_id.partner_id.bank_ids" t-as="t">
-                                                    <div t-if="t_index &lt; 3">
-                                                        IBAN
-                                                        <span t-field="t.acc_number"/>
-                                                        <t t-if="t.bank_bic">
-                                                            – BIC <span t-field="t.bank_bic"/>
-                                                        </t>
-                                                    </div>
+                                        <div>
+                                            <span
+                                                t-field="o.company_id.email"/>
+                                        </div>
+                                        <div>
+                                            <span
+                                                t-field="o.company_id.website"/>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-4">
+                                        <div t-if="o.company_id.city">
+                                            Kotipaikka:
+                                            <span
+                                                t-field="o.company_id.city"/>
+                                        </div>
+                                        <div>Y-tunnus:
+                                            <span
+                                                t-field="o.company_id.company_registry"/>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="row row-eq-height border-bottom"
+                                     style="border-top: 1px dashed gray">
+                                    <div class="col-xs-7 border-right">
+                                        <div
+                                            class="row row-eq-height border-bottom medium-row">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label">
+                                                <div>
+                                                    Saajan
+                                                    tilinumero
+                                                </div>
+                                                <div>
+                                                    Mottagarens
+                                                    kontonummer
+                                                </div>
+                                            </div>
+                                            <div class="col-xs-10 border-left">
+                                                <t t-if="o.partner_bank_id.acc_number">
+                                                    IBAN
+                                                    <t t-esc="o.partner_bank_id.acc_number"/>
                                                 </t>
-                                            </t>
+                                                <t t-if="not o.partner_bank_id.acc_number">
+                                                    <t t-foreach="o.company_id.partner_id.bank_ids"
+                                                       t-as="t">
+                                                        <div
+                                                            t-if="t_index &lt; 3">
+                                                            IBAN
+                                                            <span
+                                                                t-field="t.acc_number"/>
+                                                            <t t-if="t.bank_bic">
+                                                                – BIC
+                                                                <span
+                                                                    t-field="t.bank_bic"/>
+                                                            </t>
+                                                        </div>
+                                                    </t>
+                                                </t>
+                                            </div>
+                                        </div>
+                                        <div
+                                            class="row row-eq-height border-bottom">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label">
+                                                <div>
+                                                    Saaja
+                                                </div>
+                                                <div>
+                                                    Mottagare
+                                                </div>
+                                            </div>
+                                            <div class="col-xs-10 border-left"
+                                                 id="company-info"
+                                                 style="height: 4.5em">
+                                                <div
+                                                    t-field="o.company_id.partner_id"
+                                                    t-field-options='{"widget": "contact", "fields": ["name"], "no_marker": true}'
+                                                    style="font-size: .8em;"/>
+                                            </div>
+                                        </div>
+                                        <div class="row row-eq-height">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label">
+                                                <div>
+                                                    Maksaja
+                                                </div>
+                                                <div>
+                                                    Betalare
+                                                </div>
+                                            </div>
+                                            <div class="col-xs-10"
+                                                 id="payer-info"
+                                                 style="height: 6em;">
+                                                <div t-field="o.partner_id"
+                                                     t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'
+                                                     style="font-size: .8em;"/>
+                                            </div>
+                                        </div>
+                                        <div
+                                            class="row row-eq-height border-bottom small-row">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label"
+                                                style="font-size: 9px; text-align: right; line-height: 10px; min-height: 0;">
+                                                <div>
+                                                    Allekirjoitus
+                                                </div>
+                                                <div>
+                                                    Underskrift
+                                                </div>
+                                            </div>
+                                            <div class="col-xs-10"
+                                                 style="min-height: 0;">
+                                                <div
+                                                    style="border-bottom: 1px solid black; margin-top: 15px;"/>
+                                            </div>
+                                        </div>
+                                        <div
+                                            class="row row-eq-height small-row">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label">
+                                                <div>
+                                                    Tililtä nro
+                                                </div>
+                                                <div>
+                                                    Från konto nr
+                                                </div>
+                                            </div>
+                                            <div class="col-xs-10"
+                                                 style="border-left: 1px solid black;">
+                                            </div>
                                         </div>
                                     </div>
-                                    <div class="row row-eq-height border-bottom">
-                                        <div class="col-xs-2 bank-transfer-label">
-                                            <div>
-                                                Saaja
-                                            </div>
-                                            <div>
-                                                Mottagare
-                                            </div>
-                                        </div>
-                                        <div class="col-xs-10 border-left" id="company-info" style="height: 4.5em">
-                                            <div t-field="doc.company_id.partner_id"
-                                                 t-field-options='{"widget": "contact", "fields": ["name"], "no_marker": true}'
-                                                 style="font-size: .8em;"/>
-                                        </div>
-                                    </div>
-                                    <div class="row row-eq-height">
-                                        <div class="col-xs-2 bank-transfer-label">
-                                            <div>
-                                                Maksaja
-                                            </div>
-                                            <div>
-                                                Betalare
+                                    <div class="col-xs-5">
+                                        <div
+                                            class="row border-bottom medium-row">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label"></div>
+                                            <div class="col-xs-10">
+                                                <!-- BIC used to be here. Now there's space for a QR code. -->
                                             </div>
                                         </div>
-                                        <div class="col-xs-10" id="payer-info" style="height: 6em;">
-                                            <div t-field="doc.partner_id"
-                                                 t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'
-                                                 style="font-size: .8em;"/>
-                                        </div>
-                                    </div>
-                                    <div class="row row-eq-height border-bottom small-row">
-                                        <div class="col-xs-2 bank-transfer-label"
-                                             style="font-size: 9px; text-align: right; line-height: 10px; min-height: 0;">
-                                            <div>
-                                                Allekirjoitus
-                                            </div>
-                                            <div>
-                                                Underskrift
+                                        <div class="row border-bottom">
+                                            <div class="col-xs-12"
+                                                 style="height: 10.5em;">
+                                                Laskun numero
+                                                <t t-esc="o.number"/>
                                             </div>
                                         </div>
-                                        <div class="col-xs-10" style="min-height: 0;">
-                                            <div style="border-bottom: 1px solid black; margin-top: 15px;"/>
-                                        </div>
-                                    </div>
-                                    <div class="row row-eq-height small-row">
-                                        <div class="col-xs-2 bank-transfer-label">
-                                            <div>
-                                                Tililtä nro
+                                        <div
+                                            class="row row-eq-height border-bottom small-row">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label text-left">
+                                                <div>
+                                                    Viitenro
+                                                </div>
+                                                <div>
+                                                    Ref.nr
+                                                </div>
                                             </div>
-                                            <div>
-                                                Från konto nr
+                                            <div class="col-xs-10 border-left">
+                                                <strong>
+                                                    <span
+                                                        t-field="o.ref_number"
+                                                        class="bank-transfer-value"/>
+                                                </strong>
                                             </div>
                                         </div>
-                                        <div class="col-xs-10" style="border-left: 1px solid black;">
+                                        <div
+                                            class="row row-eq-height small-row">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label text-left">
+                                                <div>Eräpäivä</div>
+                                                <div>Förf.dag</div>
+                                            </div>
+                                            <div class="col-xs-4 border-left">
+                                                <strong>
+                                                    <span t-field="o.date_due"
+                                                          class="bank-transfer-value"/>
+                                                </strong>
+                                            </div>
+                                            <div class="col-xs-6 border-left"
+                                                 style="padding-left: 0;">
+                                                <span
+                                                    class="bank-transfer-label">
+                                                    Euro
+                                                </span>
+                                                <strong>
+                                                    <span
+                                                        t-field="o.amount_total"
+                                                        class="bank-transfer-value"
+                                                        style="float: right;"/>
+                                                </strong>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
-                                <div class="col-xs-5">
-                                    <div class="row border-bottom medium-row">
-                                        <div class="col-xs-2 bank-transfer-label"></div>
-                                        <div class="col-xs-10">
-                                            <!-- BIC used to be here. Now there's space for a QR code. -->
-                                        </div>
-                                    </div>
-                                    <div class="row border-bottom">
-                                        <div class="col-xs-12" style="height: 10.5em;">
-                                            Laskun numero <t t-esc="doc.number"/>
-                                        </div>
-                                    </div>
-                                    <div class="row row-eq-height border-bottom small-row">
-                                        <div class="col-xs-2 bank-transfer-label text-left">
-                                            <div>
-                                                Viitenro
+                                <div class="row">
+                                    <div class="col-xs-9"
+                                         style="text-align: center;">
+                                        <t t-if="o.barcode_string">
+                                            <img
+                                                style="margin-left: 0cm; margin-right: 2cm; margin-top: .2cm;"
+                                                t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;height=%s&amp;width=%s' %('Code128', o.barcode_string, 60, 600)"/>
+                                            <div class="barcode-values">
+                                                <t t-esc="o.barcode_string"/>
                                             </div>
-                                            <div>
-                                                Ref.nr
-                                            </div>
-                                        </div>
-                                        <div class="col-xs-10 border-left">
-                                            <strong>
-                                                <span t-field="doc.ref_number" class="bank-transfer-value"/>
-                                            </strong>
-                                        </div>
+                                        </t>
                                     </div>
-                                    <div class="row row-eq-height small-row">
-                                        <div class="col-xs-2 bank-transfer-label text-left">
-                                            <div>Eräpäivä</div>
-                                            <div>Förf.dag</div>
-                                        </div>
-                                        <div class="col-xs-4 border-left">
-                                            <strong>
-                                                <span t-field="doc.date_due" class="bank-transfer-value"/>
-                                            </strong>
-                                        </div>
-                                        <div class="col-xs-6 border-left" style="padding-left: 0;">
-                                            <span class="bank-transfer-label">Euro</span>
-                                            <strong>
-                                                <span t-field="doc.amount_total" class="bank-transfer-value"
-                                                      style="float: right;"/>
-                                            </strong>
-                                        </div>
+                                    <div class="col-xs-3 payment-terms">
+                                        <p>Maksu välitetään saajalle
+                                            maksujenvälityksen ehtojen
+                                            mukaisesti ja vain maksajan
+                                            tilinumeron perusteella.
+                                        </p>
+                                        <p>Betalningen fömedlas till mottagaren
+                                            enligt villkoren för
+                                            betalningsförmedling
+                                            och endast till det kontonummer som
+                                            betalaren angivit.
+                                        </p>
                                     </div>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <div class="col-xs-9" style="text-align: center;">
-                                    <t t-if="doc.barcode_string">
-                                        <img style="margin-left: 0cm; margin-right: 2cm; margin-top: .2cm;"
-                                             t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;height=%s&amp;width=%s' %('Code128', doc.barcode_string, 60, 600)"/>
-                                        <div class="barcode-values">
-                                            <t t-esc="doc.barcode_string"/>
-                                        </div>
-                                    </t>
-                                </div>
-                                <div class="col-xs-3 payment-terms">
-                                    <p>Maksu välitetään saajalle maksujenvälityksen ehtojen mukaisesti ja vain maksajan
-                                        tilinumeron perusteella.
-                                    </p>
-                                    <p>Betalningen fömedlas till mottagaren enligt villkoren för betalningsförmedling
-                                        och endast till det kontonummer som betalaren angivit.
-                                    </p>
                                 </div>
                             </div>
                         </div>
-                    </div>
+                    </t>
                 </t>
-            </t>
-        </template>
+            </xpath>
 
-        <template id="report_invoice_finnish_translate" t-name="Finnish Invoice">
-            <t t-call="report.html_container">
-                <t t-foreach="docs" t-as="doc">
-                    <t t-lang="doc.partner_id.lang" t-call="l10n_fi_invoice.report_invoice_finnish_document"/>
-                </t>
-            </t>
         </template>
-
-        <report
-                string="Finnish Invoice"
-                id="report_invoice_finnish"
-                model="account.invoice"
-                report_type="qweb-pdf"
-                name="l10n_fi_invoice.report_invoice_finnish_translate"
-                file="l10n_fi_invoice.report_invoice_finnish_translate"
-                />
 
         <!--Make custom paper format to eliminate margins-->
         <record id="paperformat_finnish" model="report.paperformat">
@@ -530,7 +604,7 @@
         </record>
 
         <!--Make report use custom paper format-->
-        <record id="report_invoice_finnish" model="ir.actions.report.xml">
+        <record id="account.account_invoices" model="ir.actions.report.xml">
             <field name="paperformat_id" ref="paperformat_finnish"/>
         </record>
 


### PR DESCRIPTION
The Finnish invoice was originally designed to be used side-by-side
with the original Odoo invoice. However this doesn't make much sense
since there are very few if any situations where we want to use the
base Odoo invoice instead of the new Finnish one. So we replace the
base Odoo invoice template by extending it and overwriting its
contents.

We also remove some unnecessary code, since we no longer need to
print the Finnish invoice version separately. We undo the
changes made in 37b176e56, since the Odoo core report wrapper
uses 'o' instead of 'doc'.

Closes #5 
#### Edit:

Fixed merge conflicts caused by merging #8. Used `git merge -Xignore-space-change --no-commit 9.0` to merge on the command line, conveniently ignoring whitespace changes.
