### PR TITLE
[FIX] Fix style errors in the invoice (#7):

### DIFF
--- a/report/report_invoice.xml
+++ b/report/report_invoice.xml
@@ -559,7 +559,7 @@
             <field name="margin_top">26.2</field>
             <field name="header_spacing">26</field>
             <!--Remove template footer-->
-            <field name="margin_bottom">0</field>
+            <field name="margin_bottom">5</field>
             <!--Remove side margins-->
             <field name="margin_left">0</field>
             <field name="margin_right">0</field>

--- a/report/report_invoice.xml
+++ b/report/report_invoice.xml
@@ -230,7 +230,7 @@
                                             </td>
                                             <td class="text-right">
                                                 <span t-field="l.price_subtotal"
-                                                      t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
+                                                      t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
                                             </td>
                                         </tr>
                                     </tbody>

--- a/report/report_invoice.xml
+++ b/report/report_invoice.xml
@@ -4,140 +4,121 @@
         <template id="report_invoice_finnish_document">
             <t t-name="account.report_invoice_document">
                 <t t-call="l10n_fi_invoice.report_layout_finnish">
-                    <div class="header" style="height: 2.62cm; position: relative;">
-                        <style type="text/css">
-                            .padding-correction {
-                            padding-right: 15px;
-                            padding-left: 15px;
-                            }
-                        </style>
-                        <div class="padding-correction" style="position: absolute; width: 100%; bottom: 0;">
-                            <div class="row">
-                                <div class="col-xs-2 col-xs-offset-1"
-                                     style="float: none; display: inline-block; vertical-align: middle;">
-                                    <img t-if="doc.company_id.logo"
-                                         t-att-src="'data:image/png;base64,%s' % doc.company_id.logo"
-                                         style="max-height: 2.1cm; max-width: 4cm;"/>
-                                </div>
-                                <div class="col-xs-4"
-                                     style="font-size: .85em; float: none; display: inline-block; vertical-align: middle;">
-                                    <div t-field="doc.company_id.partner_id"
-                                         t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
-                                </div>
-                                <div class="col-xs-5 text-left"
-                                     style="font-weight: bold; font-size: large; float: none; display: inline-block; vertical-align: bottom; width: auto; padding-left: 5px;">
-                                    <span>Invoice</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
                     <div class="page">
                         <!-- Custom CSS for reports is not trivial, see here:
                             https://github.com/odoo/odoo/issues/4359
                             Easier to just insert inline, since we aren't changing multiple reports -->
                         <style type="text/css">
                             .padding-correction {
-                            padding-right: 15px;
-                            padding-left: 15px;
+                                padding-right: 15px;
+                                padding-left: 15px;
                             }
 
                             hr {
-                            border-top: 2px solid #eee;
-                            margin-left: -15px;
-                            margin-right: -15px;
-                            margin-top: 10px;
-                            margin-bottom: 10px;
+                                border-top: 2px solid #eee;
+                                margin-left: -15px;
+                                margin-right: -15px;
+                                margin-top: 10px;
+                                margin-bottom: 10px;
                             }
 
                             .bank-transfer-wrap .row .row > div {
-                            padding-top: 5px;
-                            padding-bottom: 5px;
+                                padding-top: 5px;
+                                padding-bottom: 5px;
                             }
 
                             .bank-transfer-label {
-                            font-size: 9px;
-                            text-align: right;
-                            line-height: 10px;
-                            padding: 3px;
+                                font-size: 9px;
+                                text-align: right;
+                                line-height: 10px;
+                                padding: 3px;
                             }
 
                             .bank-transfer-value {
-                            line-height: 1.7em;
+                                line-height: 1.7em;
                             }
 
                             .text-left {
-                            text-align: left;
+                                text-align: left;
                             }
 
                             .border-right {
-                            border-right: 2px solid black;
+                                border-right: 2px solid black;
                             }
 
                             .border-left {
-                            border-left: 2px solid black;
+                                border-left: 2px solid black;
                             }
 
                             .border-bottom {
-                            border-bottom: 2px solid black;
+                                border-bottom: 2px solid black;
                             }
 
                             .medium-row > div {
-                            height: 4.9em;
+                                height: 4.9em;
                             }
 
                             .small-row > div {
-                            height: 2.5em;
+                                height: 2.5em;
                             }
 
                             .invoice-info tr td:last-child {
-                            padding-left: 3em;
+                                padding-left: 3em;
                             }
 
                             address span[itemprop=name] {
-                            font-weight: bold;
+                                font-weight: bold;
                             }
 
                             .table-condensed > thead > tr > th {
-                            border-bottom: none;
+                                border-bottom: none;
                             }
 
                             .table > tbody > tr > td {
-                            border-top: none;
+                                border-top: none;
                             }
 
                             table.products-table {
-                            border-bottom: 1px solid #eee;
+                                border-bottom: 1px solid #eee;
                             }
 
                             table.products-table-totals td {
-                            text-align: right;
-                            line-height: .9em !important;
+                                text-align: right;
+                                line-height: .9em !important;
                             }
 
                             .totals-col {
-                            width: 8em;
-                            font-weight: bold;
+                                width: 8em;
+                                font-weight: bold;
                             }
 
                             .line_number {
-                            color: gray;
-                            position: absolute;
+                                color: gray;
+                                position: absolute;
                             }
 
                             .payment-terms {
-                            font-size: .7em;
-                            margin-top: .5em;
-                            line-height: 1em;
+                                font-size: .7em;
+                                margin-top: .5em;
+                                line-height: 1em;
                             }
 
                             .payment-terms p {
-                            margin-bottom: 0;
+                                margin-bottom: 0;
+                            }
+
+                            .invoice_tbody span {
+                                display: inline-block;
+                            }
+
+                            .products-table th:nth-child(1), .products-table td:nth-child(1) {
+                                width:35em !important;
                             }
                         </style>
-                        <div class="padding-correction" style="min-height: 11.3cm">
+                        <div class="padding-correction" style="min-height: 9cm">
                             <div class="row">
                                 <div class="col-xs-6 col-xs-offset-1"
-                                     style="margin-top: 10em; margin-bottom: 4em; font-size:1.1em;">
+                                     style="margin-top: 5em; margin-bottom: 4em; font-size:1.1em;">
                                     <address t-field="doc.partner_id"
                                              t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
                                     <span t-if="doc.partner_id.vat">VAT:
@@ -146,7 +127,7 @@
                                 </div>
                                 <div class="col-xs-5">
                                     <table class="invoice-info"
-                                           style="line-height: 1.5em; position:relative; top: 7.5em;">
+                                           style="line-height: 1.5em; position:relative;">
                                         <tr>
                                             <td>
                                                 <span>Invoice number</span>
@@ -206,7 +187,7 @@
                             </div>
                         </div>
                         <hr/>
-                        <div class="padding-correction" style="min-height: 13.70cm;">
+                        <div class="padding-correction" style="min-height: 12cm;">
                             <div style="margin-bottom: 1em;">
                                 <span t-field="doc.comment"/>
                             </div>
@@ -228,7 +209,7 @@
                                     <tr t-foreach="doc.invoice_line_ids" t-as="l">
                                         <td>
                                             <span class="line_number" t-esc="str(l_index+1) + '.'"/>
-                                            <span class="col-xs-offset-2" t-field="l.name"/>
+                                            <span class="col-xs-offset-1" t-field="l.name"/>
                                         </td>
                                         <td>
                                             <span t-field="l.quantity"/>
@@ -251,245 +232,315 @@
                                 </tbody>
                             </table>
 
-                            <div class="row">
-                                <div class="col-xs-4 pull-right">
-                                    <table class="table table-condensed products-table-totals">
-                                        <tr>
-                                            <td>Total Without Taxes</td>
-                                            <td class="text-right totals-col">
-                                                <span t-field="doc.amount_untaxed"
-                                                      t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>Taxes</td>
-                                            <td class="text-right totals-col">
-                                                <span t-field="doc.amount_tax"
-                                                      t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>Total</td>
-                                            <td class="text-right totals-col">
-                                                <span t-field="doc.amount_total"
-                                                      t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
-                                            </td>
-                                        </tr>
-                                    </table>
+                            <div style="page-break-inside: avoid;">
+                                <div class="row">
+                                    <div class="col-xs-4 pull-right">
+                                        <table
+                                            class="table table-condensed products-table-totals">
+                                            <tr>
+                                                <td>Total Without Taxes</td>
+                                                <td class="text-right totals-col">
+                                                    <span
+                                                        t-field="doc.amount_untaxed"
+                                                        t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td>Taxes</td>
+                                                <td class="text-right totals-col">
+                                                    <span
+                                                        t-field="doc.amount_tax"
+                                                        t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td>Total</td>
+                                                <td class="text-right totals-col">
+                                                    <span
+                                                        t-field="doc.amount_total"
+                                                        t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </div>
+                                </div>
+
+                                <div class="row" t-if="doc.tax_line_ids">
+                                    <div class="col-xs-6 col-xs-offset-6">
+                                        <table class="table table-condensed">
+                                            <thead>
+                                                <tr>
+                                                    <th>Tax</th>
+                                                    <th class="text-right">
+                                                        Base
+                                                    </th>
+                                                    <th class="text-right">
+                                                        Amount
+                                                    </th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr t-foreach="doc.tax_line_ids"
+                                                    t-as="t">
+                                                    <td>
+                                                        <span t-field="t.name"/>
+                                                    </td>
+                                                    <td class="text-right">
+                                                        <span
+                                                            t-field="t.tax_id.amount"
+                                                            t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
+                                                    </td>
+                                                    <td class="text-right">
+                                                        <span t-field="t.amount"
+                                                              t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
                                 </div>
                             </div>
 
-                            <div class="row" t-if="doc.tax_line_ids">
-                                <div class="col-xs-6 col-xs-offset-6">
-                                    <table class="table table-condensed">
-                                        <thead>
-                                            <tr>
-                                                <th>Tax</th>
-                                                <th class="text-right">Base</th>
-                                                <th class="text-right">Amount</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <tr t-foreach="doc.tax_line_ids" t-as="t">
-                                                <td>
-                                                    <span t-field="t.name"/>
-                                                </td>
-                                                <td class="text-right">
-                                                    <span t-field="t.tax_id.amount"
-                                                          t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
-                                                </td>
-                                                <td class="text-right">
-                                                    <span t-field="t.amount"
-                                                          t-field-options='{"widget": "monetary", "display_currency": "doc.currency_id"}'/>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
                         </div>
-                        <hr/>
-                        <div class="bank-transfer-wrap last-page" style="page-break-inside: avoid;">
-                            <div class="row padding-correction" style="margin-bottom: 1em; font-size: .8em;">
-                                <div class="col-xs-4">
-                                    <div t-field="doc.company_id.partner_id"
-                                         t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
-                                </div>
-                                <div class="col-xs-4">
-                                    <div>
-                                        <span t-field="doc.company_id.phone"/>
+                        <div class="last-page" style="page-break-inside: avoid;">
+                            <hr/>
+                            <div class="bank-transfer-wrap">
+                                <div class="row padding-correction"
+                                     style="margin-bottom: 1em; font-size: .8em;">
+                                    <div class="col-xs-4">
+                                        <div t-field="doc.company_id.partner_id"
+                                             t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
                                     </div>
-                                    <div>
-                                        <span t-field="doc.company_id.email"/>
-                                    </div>
-                                    <div>
-                                        <span t-field="doc.company_id.website"/>
-                                    </div>
-                                </div>
-                                <div class="col-xs-4">
-                                    <div t-if="doc.company_id.city">Kotipaikka:
-                                        <span t-field="doc.company_id.city"/>
-                                    </div>
-                                    <div>Y-tunnus:
-                                        <span t-field="doc.company_id.company_registry"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="row row-eq-height border-bottom" style="border-top: 1px dashed gray">
-                                <div class="col-xs-7 border-right">
-                                    <div class="row row-eq-height border-bottom medium-row">
-                                        <div class="col-xs-2 bank-transfer-label">
-                                            <div>
-                                                Saajan
-                                                tilinumero
-                                            </div>
-                                            <div>
-                                                Mottagarens
-                                                kontonummer
-                                            </div>
+                                    <div class="col-xs-4">
+                                        <div>
+                                            <span
+                                                t-field="doc.company_id.phone"/>
                                         </div>
-                                        <div class="col-xs-10 border-left">
-                                            <t t-if="doc.partner_bank_id.acc_number">
-                                                IBAN
-                                                <t t-esc="doc.partner_bank_id.acc_number"/>
-                                            </t>
-                                            <t t-if="not doc.partner_bank_id.acc_number">
-                                                <t t-foreach="doc.company_id.partner_id.bank_ids" t-as="t">
-                                                    <div t-if="t_index &lt; 3">
-                                                        IBAN
-                                                        <span t-field="t.acc_number"/>
-                                                        <t t-if="t.bank_bic">
-                                                            – BIC <span t-field="t.bank_bic"/>
-                                                        </t>
-                                                    </div>
+                                        <div>
+                                            <span
+                                                t-field="doc.company_id.email"/>
+                                        </div>
+                                        <div>
+                                            <span
+                                                t-field="doc.company_id.website"/>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-4">
+                                        <div t-if="doc.company_id.city">
+                                            Kotipaikka:
+                                            <span
+                                                t-field="doc.company_id.city"/>
+                                        </div>
+                                        <div>Y-tunnus:
+                                            <span
+                                                t-field="doc.company_id.company_registry"/>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="row row-eq-height border-bottom"
+                                     style="border-top: 1px dashed gray">
+                                    <div class="col-xs-7 border-right">
+                                        <div
+                                            class="row row-eq-height border-bottom medium-row">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label">
+                                                <div>
+                                                    Saajan
+                                                    tilinumero
+                                                </div>
+                                                <div>
+                                                    Mottagarens
+                                                    kontonummer
+                                                </div>
+                                            </div>
+                                            <div class="col-xs-10 border-left">
+                                                <t t-if="doc.partner_bank_id.acc_number">
+                                                    IBAN
+                                                    <t t-esc="doc.partner_bank_id.acc_number"/>
                                                 </t>
-                                            </t>
+                                                <t t-if="not doc.partner_bank_id.acc_number">
+                                                    <t t-foreach="doc.company_id.partner_id.bank_ids"
+                                                       t-as="t">
+                                                        <div
+                                                            t-if="t_index &lt; 3">
+                                                            IBAN
+                                                            <span
+                                                                t-field="t.acc_number"/>
+                                                            <t t-if="t.bank_bic">
+                                                                – BIC
+                                                                <span
+                                                                    t-field="t.bank_bic"/>
+                                                            </t>
+                                                        </div>
+                                                    </t>
+                                                </t>
+                                            </div>
+                                        </div>
+                                        <div
+                                            class="row row-eq-height border-bottom">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label">
+                                                <div>
+                                                    Saaja
+                                                </div>
+                                                <div>
+                                                    Mottagare
+                                                </div>
+                                            </div>
+                                            <div class="col-xs-10 border-left"
+                                                 id="company-info"
+                                                 style="height: 4.5em">
+                                                <div
+                                                    t-field="doc.company_id.partner_id"
+                                                    t-field-options='{"widget": "contact", "fields": ["name"], "no_marker": true}'
+                                                    style="font-size: .8em;"/>
+                                            </div>
+                                        </div>
+                                        <div class="row row-eq-height">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label">
+                                                <div>
+                                                    Maksaja
+                                                </div>
+                                                <div>
+                                                    Betalare
+                                                </div>
+                                            </div>
+                                            <div class="col-xs-10"
+                                                 id="payer-info"
+                                                 style="height: 6em;">
+                                                <div t-field="doc.partner_id"
+                                                     t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'
+                                                     style="font-size: .8em;"/>
+                                            </div>
+                                        </div>
+                                        <div
+                                            class="row row-eq-height border-bottom small-row">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label"
+                                                style="font-size: 9px; text-align: right; line-height: 10px; min-height: 0;">
+                                                <div>
+                                                    Allekirjoitus
+                                                </div>
+                                                <div>
+                                                    Underskrift
+                                                </div>
+                                            </div>
+                                            <div class="col-xs-10"
+                                                 style="min-height: 0;">
+                                                <div
+                                                    style="border-bottom: 1px solid black; margin-top: 15px;"/>
+                                            </div>
+                                        </div>
+                                        <div
+                                            class="row row-eq-height small-row">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label">
+                                                <div>
+                                                    Tililtä nro
+                                                </div>
+                                                <div>
+                                                    Från konto nr
+                                                </div>
+                                            </div>
+                                            <div class="col-xs-10"
+                                                 style="border-left: 1px solid black;">
+                                            </div>
                                         </div>
                                     </div>
-                                    <div class="row row-eq-height border-bottom">
-                                        <div class="col-xs-2 bank-transfer-label">
-                                            <div>
-                                                Saaja
-                                            </div>
-                                            <div>
-                                                Mottagare
-                                            </div>
-                                        </div>
-                                        <div class="col-xs-10 border-left" id="company-info" style="height: 4.5em">
-                                            <div t-field="doc.company_id.partner_id"
-                                                 t-field-options='{"widget": "contact", "fields": ["name"], "no_marker": true}'
-                                                 style="font-size: .8em;"/>
-                                        </div>
-                                    </div>
-                                    <div class="row row-eq-height">
-                                        <div class="col-xs-2 bank-transfer-label">
-                                            <div>
-                                                Maksaja
-                                            </div>
-                                            <div>
-                                                Betalare
+                                    <div class="col-xs-5">
+                                        <div
+                                            class="row border-bottom medium-row">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label"></div>
+                                            <div class="col-xs-10">
+                                                <!-- BIC used to be here. Now there's space for a QR code. -->
                                             </div>
                                         </div>
-                                        <div class="col-xs-10" id="payer-info" style="height: 6em;">
-                                            <div t-field="doc.partner_id"
-                                                 t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'
-                                                 style="font-size: .8em;"/>
-                                        </div>
-                                    </div>
-                                    <div class="row row-eq-height border-bottom small-row">
-                                        <div class="col-xs-2 bank-transfer-label"
-                                             style="font-size: 9px; text-align: right; line-height: 10px; min-height: 0;">
-                                            <div>
-                                                Allekirjoitus
-                                            </div>
-                                            <div>
-                                                Underskrift
+                                        <div class="row border-bottom">
+                                            <div class="col-xs-12"
+                                                 style="height: 10.5em;">
+                                                Laskun numero
+                                                <t t-esc="doc.number"/>
                                             </div>
                                         </div>
-                                        <div class="col-xs-10" style="min-height: 0;">
-                                            <div style="border-bottom: 1px solid black; margin-top: 15px;"/>
-                                        </div>
-                                    </div>
-                                    <div class="row row-eq-height small-row">
-                                        <div class="col-xs-2 bank-transfer-label">
-                                            <div>
-                                                Tililtä nro
+                                        <div
+                                            class="row row-eq-height border-bottom small-row">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label text-left">
+                                                <div>
+                                                    Viitenro
+                                                </div>
+                                                <div>
+                                                    Ref.nr
+                                                </div>
                                             </div>
-                                            <div>
-                                                Från konto nr
+                                            <div class="col-xs-10 border-left">
+                                                <strong>
+                                                    <span
+                                                        t-field="doc.ref_number"
+                                                        class="bank-transfer-value"/>
+                                                </strong>
                                             </div>
                                         </div>
-                                        <div class="col-xs-10" style="border-left: 1px solid black;">
+                                        <div
+                                            class="row row-eq-height small-row">
+                                            <div
+                                                class="col-xs-2 bank-transfer-label text-left">
+                                                <div>Eräpäivä</div>
+                                                <div>Förf.dag</div>
+                                            </div>
+                                            <div class="col-xs-4 border-left">
+                                                <strong>
+                                                    <span t-field="doc.date_due"
+                                                          class="bank-transfer-value"/>
+                                                </strong>
+                                            </div>
+                                            <div class="col-xs-6 border-left"
+                                                 style="padding-left: 0;">
+                                                <span
+                                                    class="bank-transfer-label">
+                                                    Euro
+                                                </span>
+                                                <strong>
+                                                    <span
+                                                        t-field="doc.amount_total"
+                                                        class="bank-transfer-value"
+                                                        style="float: right;"/>
+                                                </strong>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
-                                <div class="col-xs-5">
-                                    <div class="row border-bottom medium-row">
-                                        <div class="col-xs-2 bank-transfer-label"></div>
-                                        <div class="col-xs-10">
-                                            <!-- BIC used to be here. Now there's space for a QR code. -->
-                                        </div>
-                                    </div>
-                                    <div class="row border-bottom">
-                                        <div class="col-xs-12" style="height: 10.5em;">
-                                            Laskun numero <t t-esc="doc.number"/>
-                                        </div>
-                                    </div>
-                                    <div class="row row-eq-height border-bottom small-row">
-                                        <div class="col-xs-2 bank-transfer-label text-left">
-                                            <div>
-                                                Viitenro
+                                <div class="row">
+                                    <div class="col-xs-9"
+                                         style="text-align: center;">
+                                        <t t-if="doc.barcode_string">
+                                            <img
+                                                style="margin-left: 0cm; margin-right: 2cm; margin-top: .2cm;"
+                                                t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;height=%s&amp;width=%s' %('Code128', doc.barcode_string, 60, 600)"/>
+                                            <div class="barcode-values">
+                                                <t t-esc="doc.barcode_string"/>
                                             </div>
-                                            <div>
-                                                Ref.nr
-                                            </div>
-                                        </div>
-                                        <div class="col-xs-10 border-left">
-                                            <strong>
-                                                <span t-field="doc.ref_number" class="bank-transfer-value"/>
-                                            </strong>
-                                        </div>
+                                        </t>
                                     </div>
-                                    <div class="row row-eq-height small-row">
-                                        <div class="col-xs-2 bank-transfer-label text-left">
-                                            <div>Eräpäivä</div>
-                                            <div>Förf.dag</div>
-                                        </div>
-                                        <div class="col-xs-4 border-left">
-                                            <strong>
-                                                <span t-field="doc.date_due" class="bank-transfer-value"/>
-                                            </strong>
-                                        </div>
-                                        <div class="col-xs-6 border-left" style="padding-left: 0;">
-                                            <span class="bank-transfer-label">Euro</span>
-                                            <strong>
-                                                <span t-field="doc.amount_total" class="bank-transfer-value"
-                                                      style="float: right;"/>
-                                            </strong>
-                                        </div>
+                                    <div class="col-xs-3 payment-terms">
+                                        <p>Maksu välitetään saajalle
+                                            maksujenvälityksen ehtojen
+                                            mukaisesti ja vain maksajan
+                                            tilinumeron perusteella.
+                                        </p>
+                                        <p>Betalningen fömedlas till mottagaren
+                                            enligt villkoren för
+                                            betalningsförmedling
+                                            och endast till det kontonummer som
+                                            betalaren angivit.
+                                        </p>
                                     </div>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <div class="col-xs-9" style="text-align: center;">
-                                    <t t-if="doc.barcode_string">
-                                        <img style="margin-left: 0cm; margin-right: 2cm; margin-top: .2cm;"
-                                             t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;height=%s&amp;width=%s' %('Code128', doc.barcode_string, 60, 600)"/>
-                                        <div class="barcode-values">
-                                            <t t-esc="doc.barcode_string"/>
-                                        </div>
-                                    </t>
-                                </div>
-                                <div class="col-xs-3 payment-terms">
-                                    <p>Maksu välitetään saajalle maksujenvälityksen ehtojen mukaisesti ja vain maksajan
-                                        tilinumeron perusteella.
-                                    </p>
-                                    <p>Betalningen fömedlas till mottagaren enligt villkoren för betalningsförmedling
-                                        och endast till det kontonummer som betalaren angivit.
-                                    </p>
                                 </div>
                             </div>
                         </div>
+
                     </div>
                 </t>
             </t>
@@ -519,8 +570,8 @@
             <field name="format">A4</field>
             <field name="orientation">Portrait</field>
             <!--Remove template header-->
-            <field name="margin_top">0</field>
-            <field name="header_spacing">0</field>
+            <field name="margin_top">26.2</field>
+            <field name="header_spacing">26</field>
             <!--Remove template footer-->
             <field name="margin_bottom">0</field>
             <!--Remove side margins-->

--- a/report/report_layout.xml
+++ b/report/report_layout.xml
@@ -13,7 +13,7 @@
 
                 <t t-call="l10n_fi_invoice.report_layout_header_finnish"/>
                 <t t-raw="0"/>
-                <t t-call="l10n_fi_invoice.report_layout_footer_finnish"/>
+                <!--<t t-call="l10n_fi_invoice.report_layout_footer_finnish"/>-->
             </t>
         </template>
     </data>

--- a/report/report_layout_header.xml
+++ b/report/report_layout_header.xml
@@ -14,13 +14,13 @@
                             <div class="row">
                                 <div class="col-xs-2 col-xs-offset-1"
                                      style="float: none; display: inline-block; vertical-align: middle;">
-                                    <img t-if="doc.company_id.logo"
-                                         t-att-src="'data:image/png;base64,%s' % doc.company_id.logo"
+                                    <img t-if="o.company_id.logo"
+                                         t-att-src="'data:image/png;base64,%s' % o.company_id.logo"
                                          style="max-height: 2.1cm; max-width: 4cm;"/>
                                 </div>
                                 <div class="col-xs-4"
                                      style="font-size: .85em; float: none; display: inline-block; vertical-align: middle;">
-                                    <div t-field="doc.company_id.partner_id"
+                                    <div t-field="o.company_id.partner_id"
                                          t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
                                 </div>
                                 <div class="col-xs-5 text-left"

--- a/report/report_layout_header.xml
+++ b/report/report_layout_header.xml
@@ -3,7 +3,33 @@
     <data>
         <template id="report_layout_header_finnish">
             <t t-name="l10n_fi_invoice.external_layout_header_finnish">
-
+                <div class="header" style="height: 2.62cm; position: relative;">
+                        <style type="text/css">
+                            .padding-correction {
+                                padding-right: 15px;
+                                padding-left: 15px;
+                            }
+                        </style>
+                        <div class="padding-correction" style="position: absolute; width: 100%; bottom: 0;">
+                            <div class="row">
+                                <div class="col-xs-2 col-xs-offset-1"
+                                     style="float: none; display: inline-block; vertical-align: middle;">
+                                    <img t-if="doc.company_id.logo"
+                                         t-att-src="'data:image/png;base64,%s' % doc.company_id.logo"
+                                         style="max-height: 2.1cm; max-width: 4cm;"/>
+                                </div>
+                                <div class="col-xs-4"
+                                     style="font-size: .85em; float: none; display: inline-block; vertical-align: middle;">
+                                    <div t-field="doc.company_id.partner_id"
+                                         t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
+                                </div>
+                                <div class="col-xs-5 text-left"
+                                     style="font-weight: bold; font-size: large; float: none; display: inline-block; vertical-align: bottom; width: auto; padding-left: 5px;">
+                                    <span>Invoice</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
             </t>
         </template>
     </data>


### PR DESCRIPTION
- The invoice lines wrapped text poorly for long line descriptions.
  The text is now in line with the product name.
- The margins for the header and the start of the invoice were
  pretty large. These have been decreased somewhat. Various
  other margins and min-heights have also been adjusted.
- The bank statement part, if it propagated to the following page,
  overlapped with the header of that page. The header has been
  properly separated to a separate template, so that the page and
  header are not rendered in the same space for PDF reports.
- The sum and taxes part of the invoice is forced to stay in
  one part so it doesn't split on page breaks.

Closes #7

Example PDF images:

![image](https://cloud.githubusercontent.com/assets/2587901/17739953/847b208a-649f-11e6-9c83-46486fd0ee27.png)

---

![image](https://cloud.githubusercontent.com/assets/2587901/17739988/a12b60e6-649f-11e6-9e56-ca12845bec19.png)

---

![image](https://cloud.githubusercontent.com/assets/2587901/17740008/b565c6e6-649f-11e6-9282-fe02fc338577.png)
