### PR TITLE
[FIX] Multiple style and code fixes:

### DIFF
--- a/__openerp__.py
+++ b/__openerp__.py
@@ -28,8 +28,7 @@
     "website": "http://avoin.systems",
     "images": ["static/description/icon.png"],
     "depends": [
-        'base',
-        'account'
+        'l10n_fi'
     ],
     "description": """
 Finnish Invoice

--- a/i18n/fi.po
+++ b/i18n/fi.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0-20150501\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-15 14:22+0000\n"
-"PO-Revision-Date: 2016-08-15 17:26+0200\n"
+"POT-Creation-Date: 2016-08-23 13:16+0000\n"
+"PO-Revision-Date: 2016-08-23 16:20+0200\n"
 "Last-Translator: \n"
 "Language-Team: Avoin.Systems\n"
 "Language: fi_FI\n"
@@ -23,7 +23,10 @@ msgstr ""
 
 #. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
-msgid "<span class=\"bank-transfer-label\">Euro</span>"
+msgid ""
+"<span class=\"bank-transfer-label\">\n"
+"                                                        Euro\n"
+"                                                    </span>"
 msgstr ""
 
 #. module: l10n_fi_invoice
@@ -63,6 +66,17 @@ msgid "Barcode String"
 msgstr "Viivakoodi"
 
 #. module: l10n_fi_invoice
+#: code:addons/l10n_fi_invoice/model/account_invoice.py:94
+#: model:ir.model.fields,help:l10n_fi_invoice.field_account_invoice_barcode_string
+#, python-format
+msgid ""
+"Barcode generated in accordance with http://www.finanssiala.fi/"
+"maksujenvalitys/dokumentit/Pankkiviivakoodi-opas.pdf"
+msgstr ""
+"Viivakoodi finanssialan sääntöjen mukaisesti: http://www.finanssiala.fi/"
+"maksujenvalitys/dokumentit/Pankkiviivakoodi-opas.pdf"
+
+#. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
 msgid "Base"
 msgstr "Verotettava"
@@ -77,14 +91,16 @@ msgstr ""
 #. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
 msgid ""
-"Betalningen fömedlas till mottagaren enligt villkoren för "
-"betalningsförmedling\n"
-"                                        och endast till det kontonummer som "
-"betalaren angivit."
+"Betalningen fömedlas till mottagaren\n"
+"                                                enligt villkoren för\n"
+"                                                betalningsförmedling\n"
+"                                                och endast till det "
+"kontonummer som\n"
+"                                                betalaren angivit."
 msgstr ""
 
 #. module: l10n_fi_invoice
-#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
+#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_layout_header_finnish
 msgid "Cancelled Invoice"
 msgstr "Peruttu Lasku"
 
@@ -104,7 +120,7 @@ msgid "Discount (%)"
 msgstr "Alennus (%)"
 
 #. module: l10n_fi_invoice
-#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
+#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_layout_header_finnish
 msgid "Draft Invoice"
 msgstr "Laskuluonnos"
 
@@ -123,11 +139,6 @@ msgstr ""
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_layout_footer_finnish
 msgid "Fax:"
 msgstr "Faksi:"
-
-#. module: l10n_fi_invoice
-#: model:ir.actions.report.xml,name:l10n_fi_invoice.report_invoice_finnish
-msgid "Finnish Invoice"
-msgstr "Suomalainen laskupohja"
 
 # Swedish, do not translate
 #. module: l10n_fi_invoice
@@ -148,21 +159,8 @@ msgid "IBAN"
 msgstr ""
 
 #. module: l10n_fi_invoice
-#: code:addons/l10n_fi_invoice/model/account_invoice.py:75
-#: model:ir.model.fields,help:l10n_fi_invoice.field_account_invoice_invoice_number
-#, python-format
-msgid ""
-"Identifier number used to refer to this invoice in accordance with https://"
-"www.fkl.fi/teemasivut/sepa/tekninen_dokumentaatio/Dokumentit/"
-"kotimaisen_viitteen_rakenneohje.pdf"
-msgstr ""
-"Laksun tunnistenumero jolla voidaan viitata yksiselitteisesti tähän laskuun. "
-"Katso https://www.fkl.fi/teemasivut/sepa/tekninen_dokumentaatio/Dokumentit/"
-"kotimaisen_viitteen_rakenneohje.pdf."
-
-#. module: l10n_fi_invoice
 #: model:ir.model,name:l10n_fi_invoice.model_account_invoice
-#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
+#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_layout_header_finnish
 msgid "Invoice"
 msgstr "Lasku"
 
@@ -170,23 +168,6 @@ msgstr "Lasku"
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
 msgid "Invoice Date"
 msgstr "Laskun pvm"
-
-#. module: l10n_fi_invoice
-#: model:ir.model.fields,field_description:l10n_fi_invoice.field_account_invoice_invoice_number
-msgid "Invoice number"
-msgstr "Laskun numero"
-
-#. module: l10n_fi_invoice
-#: code:addons/l10n_fi_invoice/model/account_invoice.py:85
-#: model:ir.model.fields,help:l10n_fi_invoice.field_account_invoice_ref_number
-#, python-format
-msgid ""
-"Invoice reference number in accordance with https://www.fkl.fi/teemasivut/"
-"sepa/tekninen_dokumentaatio/Dokumentit/kotimaisen_viitteen_rakenneohje.pdf"
-msgstr ""
-"Viitenumero. Katso Invoice reference number in accordance with https://www."
-"fkl.fi/teemasivut/sepa/tekninen_dokumentaatio/Dokumentit/"
-"kotimaisen_viitteen_rakenneohje.pdf"
 
 # Already Finnish
 #. module: l10n_fi_invoice
@@ -206,13 +187,13 @@ msgstr ""
 msgid "Maksaja"
 msgstr ""
 
-# Already Finnish
 #. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
 msgid ""
-"Maksu välitetään saajalle maksujenvälityksen ehtojen mukaisesti ja vain "
-"maksajan\n"
-"                                        tilinumeron perusteella."
+"Maksu välitetään saajalle\n"
+"                                                maksujenvälityksen ehtojen\n"
+"                                                mukaisesti ja vain maksajan\n"
+"                                                tilinumeron perusteella."
 msgstr ""
 
 # Swedish, do not translate
@@ -226,7 +207,7 @@ msgstr ""
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
 msgid ""
 "Mottagarens\n"
-"                                                kontonummer"
+"                                                        kontonummer"
 msgstr ""
 
 #. module: l10n_fi_invoice
@@ -235,7 +216,7 @@ msgid "Our reference"
 msgstr "Viitteemme"
 
 #. module: l10n_fi_invoice
-#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
+#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_layout_header_finnish
 msgid "PRO-FORMA"
 msgstr ""
 
@@ -271,12 +252,7 @@ msgid "Ref.nr"
 msgstr ""
 
 #. module: l10n_fi_invoice
-#: model:ir.model.fields,field_description:l10n_fi_invoice.field_account_invoice_ref_number
-msgid "Reference Number"
-msgstr "Viitenumero"
-
-#. module: l10n_fi_invoice
-#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
+#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_layout_header_finnish
 msgid "Refund"
 msgstr "Hyvitys"
 
@@ -286,12 +262,11 @@ msgstr "Hyvitys"
 msgid "Saaja"
 msgstr ""
 
-# Already Finnish
 #. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
 msgid ""
 "Saajan\n"
-"                                                tilinumero"
+"                                                        tilinumero"
 msgstr ""
 
 #. module: l10n_fi_invoice
@@ -305,7 +280,7 @@ msgid "Taxes"
 msgstr "Verot"
 
 #. module: l10n_fi_invoice
-#: code:addons/l10n_fi_invoice/model/account_invoice.py:92
+#: code:addons/l10n_fi_invoice/model/account_invoice.py:87
 #: model:ir.model.fields,help:l10n_fi_invoice.field_account_invoice_date_delivered
 #, python-format
 msgid ""
@@ -323,8 +298,8 @@ msgstr ""
 
 #. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
-msgid "Total"
-msgstr "Summa"
+msgid "To Pay"
+msgstr "Maksettava summa"
 
 #. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
@@ -348,12 +323,12 @@ msgid "VAT:"
 msgstr "ALV:"
 
 #. module: l10n_fi_invoice
-#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
+#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_layout_header_finnish
 msgid "Vendor Bill"
 msgstr "Ostolasku"
 
 #. module: l10n_fi_invoice
-#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
+#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_layout_header_finnish
 msgid "Vendor Refund"
 msgstr "Oston Hyvitys"
 
@@ -379,22 +354,47 @@ msgstr ""
 msgid "Your reference"
 msgstr "Viitteenne"
 
-#. module: l10n_fi_invoice
-#: code:addons/l10n_fi_invoice/model/account_invoice.py:99
-#: model:ir.model.fields,help:l10n_fi_invoice.field_account_invoice_barcode_string
-#, python-format
-msgid ""
-"https://www.fkl.fi/teemasivut/sepa/tekninen_dokumentaatio/Dokumentit/"
-"Pankkiviivakoodi-opas.pdf"
-msgstr ""
-"https://www.fkl.fi/teemasivut/sepa/tekninen_dokumentaatio/Dokumentit/"
-"kotimaisen_viitteen_rakenneohje.pdf"
-
 # No need to translate
 #. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
 msgid "– BIC"
 msgstr ""
+
+#~ msgid "Finnish Invoice"
+#~ msgstr "Suomalainen laskupohja"
+
+#~ msgid ""
+#~ "Identifier number used to refer to this invoice in accordance with "
+#~ "https://www.fkl.fi/teemasivut/sepa/tekninen_dokumentaatio/Dokumentit/"
+#~ "kotimaisen_viitteen_rakenneohje.pdf"
+#~ msgstr ""
+#~ "Laksun tunnistenumero jolla voidaan viitata yksiselitteisesti tähän "
+#~ "laskuun. Katso https://www.fkl.fi/teemasivut/sepa/tekninen_dokumentaatio/"
+#~ "Dokumentit/kotimaisen_viitteen_rakenneohje.pdf."
+
+#~ msgid "Invoice number"
+#~ msgstr "Laskun numero"
+
+#~ msgid ""
+#~ "Invoice reference number in accordance with https://www.fkl.fi/teemasivut/"
+#~ "sepa/tekninen_dokumentaatio/Dokumentit/kotimaisen_viitteen_rakenneohje.pdf"
+#~ msgstr ""
+#~ "Viitenumero. Katso Invoice reference number in accordance with https://"
+#~ "www.fkl.fi/teemasivut/sepa/tekninen_dokumentaatio/Dokumentit/"
+#~ "kotimaisen_viitteen_rakenneohje.pdf"
+
+#~ msgid "Reference Number"
+#~ msgstr "Viitenumero"
+
+#~ msgid "Total"
+#~ msgstr "Summa"
+
+#~ msgid ""
+#~ "https://www.fkl.fi/teemasivut/sepa/tekninen_dokumentaatio/Dokumentit/"
+#~ "Pankkiviivakoodi-opas.pdf"
+#~ msgstr ""
+#~ "https://www.fkl.fi/teemasivut/sepa/tekninen_dokumentaatio/Dokumentit/"
+#~ "kotimaisen_viitteen_rakenneohje.pdf"
 
 #~ msgid "Date due"
 #~ msgstr "Eräpäivä"

--- a/i18n/l10n_fi_invoice.pot
+++ b/i18n/l10n_fi_invoice.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 9.0e-20160815\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-15 14:22+0000\n"
-"PO-Revision-Date: 2016-08-15 14:22+0000\n"
+"POT-Creation-Date: 2016-08-23 13:16+0000\n"
+"PO-Revision-Date: 2016-08-23 13:16+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -22,7 +22,9 @@ msgstr ""
 
 #. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
-msgid "<span class=\"bank-transfer-label\">Euro</span>"
+msgid "<span class=\"bank-transfer-label\">\n"
+"                                                        Euro\n"
+"                                                    </span>"
 msgstr ""
 
 #. module: l10n_fi_invoice
@@ -61,6 +63,13 @@ msgid "Barcode String"
 msgstr ""
 
 #. module: l10n_fi_invoice
+#: code:addons/l10n_fi_invoice/model/account_invoice.py:94
+#: model:ir.model.fields,help:l10n_fi_invoice.field_account_invoice_barcode_string
+#, python-format
+msgid "Barcode generated in accordance with http://www.finanssiala.fi/maksujenvalitys/dokumentit/Pankkiviivakoodi-opas.pdf"
+msgstr ""
+
+#. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
 msgid "Base"
 msgstr ""
@@ -72,12 +81,15 @@ msgstr ""
 
 #. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
-msgid "Betalningen fömedlas till mottagaren enligt villkoren för betalningsförmedling\n"
-"                                        och endast till det kontonummer som betalaren angivit."
+msgid "Betalningen fömedlas till mottagaren\n"
+"                                                enligt villkoren för\n"
+"                                                betalningsförmedling\n"
+"                                                och endast till det kontonummer som\n"
+"                                                betalaren angivit."
 msgstr ""
 
 #. module: l10n_fi_invoice
-#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
+#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_layout_header_finnish
 msgid "Cancelled Invoice"
 msgstr ""
 
@@ -97,7 +109,7 @@ msgid "Discount (%)"
 msgstr ""
 
 #. module: l10n_fi_invoice
-#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
+#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_layout_header_finnish
 msgid "Draft Invoice"
 msgstr ""
 
@@ -117,11 +129,6 @@ msgid "Fax:"
 msgstr ""
 
 #. module: l10n_fi_invoice
-#: model:ir.actions.report.xml,name:l10n_fi_invoice.report_invoice_finnish
-msgid "Finnish Invoice"
-msgstr ""
-
-#. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
 msgid "Från konto nr"
 msgstr ""
@@ -137,33 +144,14 @@ msgid "IBAN"
 msgstr ""
 
 #. module: l10n_fi_invoice
-#: code:addons/l10n_fi_invoice/model/account_invoice.py:75
-#: model:ir.model.fields,help:l10n_fi_invoice.field_account_invoice_invoice_number
-#, python-format
-msgid "Identifier number used to refer to this invoice in accordance with https://www.fkl.fi/teemasivut/sepa/tekninen_dokumentaatio/Dokumentit/kotimaisen_viitteen_rakenneohje.pdf"
-msgstr ""
-
-#. module: l10n_fi_invoice
 #: model:ir.model,name:l10n_fi_invoice.model_account_invoice
-#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
+#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_layout_header_finnish
 msgid "Invoice"
 msgstr ""
 
 #. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
 msgid "Invoice Date"
-msgstr ""
-
-#. module: l10n_fi_invoice
-#: model:ir.model.fields,field_description:l10n_fi_invoice.field_account_invoice_invoice_number
-msgid "Invoice number"
-msgstr ""
-
-#. module: l10n_fi_invoice
-#: code:addons/l10n_fi_invoice/model/account_invoice.py:85
-#: model:ir.model.fields,help:l10n_fi_invoice.field_account_invoice_ref_number
-#, python-format
-msgid "Invoice reference number in accordance with https://www.fkl.fi/teemasivut/sepa/tekninen_dokumentaatio/Dokumentit/kotimaisen_viitteen_rakenneohje.pdf"
 msgstr ""
 
 #. module: l10n_fi_invoice
@@ -183,8 +171,10 @@ msgstr ""
 
 #. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
-msgid "Maksu välitetään saajalle maksujenvälityksen ehtojen mukaisesti ja vain maksajan\n"
-"                                        tilinumeron perusteella."
+msgid "Maksu välitetään saajalle\n"
+"                                                maksujenvälityksen ehtojen\n"
+"                                                mukaisesti ja vain maksajan\n"
+"                                                tilinumeron perusteella."
 msgstr ""
 
 #. module: l10n_fi_invoice
@@ -195,7 +185,7 @@ msgstr ""
 #. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
 msgid "Mottagarens\n"
-"                                                kontonummer"
+"                                                        kontonummer"
 msgstr ""
 
 #. module: l10n_fi_invoice
@@ -204,7 +194,7 @@ msgid "Our reference"
 msgstr ""
 
 #. module: l10n_fi_invoice
-#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
+#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_layout_header_finnish
 msgid "PRO-FORMA"
 msgstr ""
 
@@ -239,12 +229,7 @@ msgid "Ref.nr"
 msgstr ""
 
 #. module: l10n_fi_invoice
-#: model:ir.model.fields,field_description:l10n_fi_invoice.field_account_invoice_ref_number
-msgid "Reference Number"
-msgstr ""
-
-#. module: l10n_fi_invoice
-#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
+#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_layout_header_finnish
 msgid "Refund"
 msgstr ""
 
@@ -256,7 +241,7 @@ msgstr ""
 #. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
 msgid "Saajan\n"
-"                                                tilinumero"
+"                                                        tilinumero"
 msgstr ""
 
 #. module: l10n_fi_invoice
@@ -270,7 +255,7 @@ msgid "Taxes"
 msgstr ""
 
 #. module: l10n_fi_invoice
-#: code:addons/l10n_fi_invoice/model/account_invoice.py:92
+#: code:addons/l10n_fi_invoice/model/account_invoice.py:87
 #: model:ir.model.fields,help:l10n_fi_invoice.field_account_invoice_date_delivered
 #, python-format
 msgid "The date when the invoiced product or service was considered delivered, for taxation purposes."
@@ -283,7 +268,7 @@ msgstr ""
 
 #. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
-msgid "Total"
+msgid "To Pay"
 msgstr ""
 
 #. module: l10n_fi_invoice
@@ -307,12 +292,12 @@ msgid "VAT:"
 msgstr ""
 
 #. module: l10n_fi_invoice
-#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
+#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_layout_header_finnish
 msgid "Vendor Bill"
 msgstr ""
 
 #. module: l10n_fi_invoice
-#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
+#: model:ir.ui.view,arch_db:l10n_fi_invoice.report_layout_header_finnish
 msgid "Vendor Refund"
 msgstr ""
 
@@ -334,13 +319,6 @@ msgstr ""
 #. module: l10n_fi_invoice
 #: model:ir.ui.view,arch_db:l10n_fi_invoice.report_invoice_finnish_document
 msgid "Your reference"
-msgstr ""
-
-#. module: l10n_fi_invoice
-#: code:addons/l10n_fi_invoice/model/account_invoice.py:99
-#: model:ir.model.fields,help:l10n_fi_invoice.field_account_invoice_barcode_string
-#, python-format
-msgid "https://www.fkl.fi/teemasivut/sepa/tekninen_dokumentaatio/Dokumentit/Pankkiviivakoodi-opas.pdf"
 msgstr ""
 
 #. module: l10n_fi_invoice

--- a/report/report_invoice.xml
+++ b/report/report_invoice.xml
@@ -124,8 +124,8 @@
                                          style="margin-top: 5em; margin-bottom: 4em; font-size:1.1em;">
                                         <address t-field="o.partner_id"
                                                  t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
-                                        <span t-if="o.partner_id.vat">VAT:
-                                            <span t-field="o.partner_id.vat"/>
+                                        <span t-if="o.partner_id.vat">
+                                            VAT: <span t-field="o.partner_id.vat"/>
                                         </span>
                                     </div>
                                     <div class="col-xs-5">
@@ -141,11 +141,10 @@
                                             </tr>
                                             <tr>
                                                 <td>
-                                                    <span>Invoice reference
-                                                    </span>
+                                                    <span>Invoice reference</span>
                                                 </td>
                                                 <td>
-                                                    <t t-esc="o.ref_number"/>
+                                                    <t t-esc="o.payment_reference"/>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -191,7 +190,7 @@
                                 </div>
                             </div>
                             <hr/>
-                            <div class="padding-correction" style="min-height: 12cm;">
+                            <div class="padding-correction" style="min-height: 11.5cm;">
                                 <div style="margin-bottom: 1em;">
                                     <span t-field="o.comment"/>
                                 </div>
@@ -237,6 +236,32 @@
                                 </table>
 
                                 <div style="page-break-inside: avoid;">
+                                    <div class="row" t-if="o.tax_line_ids">
+                                        <div class="col-xs-6">
+                                            <table class="table table-condensed">
+                                                <thead>
+                                                    <tr>
+                                                        <th>Tax</th>
+                                                        <th class="text-right">Base</th>
+                                                        <th class="text-right">Amount</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <tr t-foreach="o.tax_line_ids" t-as="t">
+                                                        <td><span t-field="t.name"/></td>
+                                                        <td class="text-right">
+                                                            <span t-field="t.base"
+                                                                t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                        </td>
+                                                        <td class="text-right">
+                                                            <span t-field="t.amount"
+                                                                t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </div>
                                     <div class="row">
                                         <div class="col-xs-4 pull-right">
                                             <table
@@ -257,8 +282,8 @@
                                                             t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
                                                     </td>
                                                 </tr>
-                                                <tr>
-                                                    <td>Total</td>
+                                                <tr style="font-size: larger;">
+                                                    <td style="font-weight: bold;">To Pay</td>
                                                     <td class="text-right totals-col">
                                                         <span
                                                             t-field="o.amount_total"
@@ -269,40 +294,6 @@
                                         </div>
                                     </div>
 
-                                    <div class="row" t-if="o.tax_line_ids">
-                                        <div class="col-xs-6 col-xs-offset-6">
-                                            <table class="table table-condensed">
-                                                <thead>
-                                                    <tr>
-                                                        <th>Tax</th>
-                                                        <th class="text-right">
-                                                            Base
-                                                        </th>
-                                                        <th class="text-right">
-                                                            Amount
-                                                        </th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody>
-                                                    <tr t-foreach="o.tax_line_ids"
-                                                        t-as="t">
-                                                        <td>
-                                                            <span t-field="t.name"/>
-                                                        </td>
-                                                        <td class="text-right">
-                                                            <span
-                                                                t-field="t.tax_id.amount"
-                                                                t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
-                                                        </td>
-                                                        <td class="text-right">
-                                                            <span t-field="t.amount"
-                                                                  t-field-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
-                                                        </td>
-                                                    </tr>
-                                                </tbody>
-                                            </table>
-                                        </div>
-                                    </div>
                                 </div>
                             </div>
                             <div class="last-page" style="page-break-inside: avoid;">
@@ -481,7 +472,7 @@
                                                 <div class="col-xs-10 border-left">
                                                     <strong>
                                                         <span
-                                                            t-field="o.ref_number"
+                                                            t-field="o.payment_reference"
                                                             class="bank-transfer-value"/>
                                                     </strong>
                                                 </div>

--- a/report/report_layout_header.xml
+++ b/report/report_layout_header.xml
@@ -25,7 +25,13 @@
                                 </div>
                                 <div class="col-xs-5 text-left"
                                      style="font-weight: bold; font-size: large; float: none; display: inline-block; vertical-align: bottom; width: auto; padding-left: 5px;">
-                                    <span>Invoice</span>
+                                    <span t-if="o.type == 'out_invoice' and (o.state == 'open' or o.state == 'paid')">Invoice</span>
+                                    <span t-if="o.type == 'out_invoice' and o.state == 'proforma2'">PRO-FORMA</span>
+                                    <span t-if="o.type == 'out_invoice' and o.state == 'draft'">Draft Invoice</span>
+                                    <span t-if="o.type == 'out_invoice' and o.state == 'cancel'">Cancelled Invoice</span>
+                                    <span t-if="o.type == 'out_refund'">Refund</span>
+                                    <span t-if="o.type == 'in_refund'">Vendor Refund</span>
+                                    <span t-if="o.type == 'in_invoice'">Vendor Bill</span>
                                 </div>
                             </div>
                         </div>

--- a/static/description/index.html
+++ b/static/description/index.html
@@ -23,7 +23,7 @@
                 A beautiful invoice template that
             <ul>
                 <li>meets the Finnish invoicing regulations,</li>
-                <li>generates invoice reference number,</li>
+                <li>uses a Finnish invoice reference number,</li>
                 <li>generates payment barcode,</li>
                 <li>...you name it</li>
             </ul>
@@ -60,10 +60,8 @@
         </div>
         <div class="oe_span6">
             <p class="oe_mt32">
-                The installation of the module adds a new PDF template, that
-                can be used for printing and emailing invoices. Please note
-                that using this template with email requires setting the
-                invoice template to the email template manually.
+                The installation of the module replaces the base invoice
+                tempate with a Finnish version.
             </p>
 
             <p class="oe_mt32">

--- a/view/account_invoice.xml
+++ b/view/account_invoice.xml
@@ -10,12 +10,6 @@
                 <field name="date_invoice" position="after">
                     <field name="date_delivered"/>
                 </field>
-
-                <xpath expr="//notebook/page[2]//group/field[@name='name']" position="after">
-                    <field name="invoice_number"/>
-                    <field name="ref_number"/>
-                </xpath>
-
             </field>
         </record>
     </data>


### PR DESCRIPTION
- Fixed bug where bank portion changed pages if it had a barcode attached
- Fixed barcode field to generate correct barcode for RF type references
- Moved taxation section to the left and above the sum portion
- Specially bolded and enlarged the total sum of the invoice
- Added some translations
- Ported module over to use l10n_fi field payment_reference
- Brought back the fix to #6 that was erroneously removed when fixing merge conflicts in 42fa8a71a4b232245c4c8a0ea91e289345893b2c
